### PR TITLE
修复写源工具导出文件触发弹窗选择目录时会自动清空 file/js目录的不合理的逻辑。

### DIFF
--- a/src/main/core/ipc.ts
+++ b/src/main/core/ipc.ts
@@ -1,11 +1,11 @@
-import { electronApp, is, platform } from '@electron-toolkit/utils';
-import { exec } from 'child_process';
-import { app, globalShortcut, ipcMain, shell } from 'electron';
+import {electronApp, is, platform} from '@electron-toolkit/utils';
+import {exec} from 'child_process';
+import {app, globalShortcut, ipcMain, shell} from 'electron';
 import fs from 'fs-extra';
-import { join } from 'path';
+import {join} from 'path';
 
 import logger from './logger';
-import { setting } from './db/service';
+import {setting} from './db/service';
 import puppeteerInElectron from '../utils/pie';
 
 const tmpDir = async (path: string) => {
@@ -78,11 +78,12 @@ const ipcListen = () => {
   ipcMain.on('tmpdir-manage', (event, action, trails) => {
     let formatPath = join(app.getPath('userData'), trails);
     if (action === 'rmdir' || action === 'mkdir' || action === 'init') tmpDir(formatPath);
+    if (action === 'make') fs.ensureDirSync(formatPath);
     if (action === 'size') event.reply('tmpdir-manage-size', getFolderSize(formatPath));
   });
 
   ipcMain.handle('ffmpeg-thumbnail', async (_, url, key) => {
-    let uaState: any = setting.find({ key: 'ua' }).value;
+    let uaState: any = setting.find({key: 'ua'}).value;
     const formatPath = is.dev
       ? join(process.cwd(), 'thumbnail', `${key}.jpg`)
       : join(app.getPath('userData'), 'thumbnail', `${key}.jpg`);
@@ -120,7 +121,7 @@ const ipcListen = () => {
 
   ipcMain.handle('ffmpeg-installed-check', async () => {
     try {
-      const { stdout } = await exec('ffmpeg -version');
+      const {stdout} = await exec('ffmpeg -version');
       logger.info(`[ipcMain] FFmpeg is installed. ${stdout}`);
       return true;
     } catch (err) {
@@ -130,7 +131,7 @@ const ipcListen = () => {
   });
 
   ipcMain.handle('sniffer-media', async (_, url, script, customRegex) => {
-    const ua = setting.find({ key: 'ua' }).value;
+    const ua = setting.find({key: 'ua'}).value;
     const res = await puppeteerInElectron(url, script, customRegex, ua);
     return res;
   });
@@ -175,4 +176,4 @@ const ipcListen = () => {
   });
 };
 
-export { ipcListen, tmpDir };
+export {ipcListen, tmpDir};

--- a/src/renderer/src/pages/setting/tool/EditSource.vue
+++ b/src/renderer/src/pages/setting/tool/EditSource.vue
@@ -657,7 +657,7 @@ const exportFileEvent = async () => {
   };
 
   try {
-    await window.electron.ipcRenderer.send('tmpdir-manage', 'init', 'file/js');
+    await window.electron.ipcRenderer.send('tmpdir-manage', 'make', 'file/js');
 
     const userDataPath = await window.electron.ipcRenderer.invoke('read-path', 'userData');
     const defaultPath = await window.electron.ipcRenderer.invoke('path-join', userDataPath, `file/js/${title}.js`);

--- a/src/renderer/src/utils/drpy/drpy_suggestions/drpy_suggestions.ts
+++ b/src/renderer/src/utils/drpy/drpy_suggestions/drpy_suggestions.ts
@@ -168,6 +168,19 @@ var rule = {
     documentation: `var rule = {};`,
   },
   {
+    label: '$Object',
+    insertText: `
+Object.assign(muban.mxone5.二级,{
+    //tabs: '.module-tab-item',
+    lists: '.module-row-one:eq(#id)&&a.module-row-text',
+    list_text:'h4&&Text',
+    list_url:'a&&data-clipboard-text',
+});
+    `.trim(),
+    detail: '继承模板前修改模板的二级属性',
+    documentation: `Object.assign(muban.xx模板.xx属性,{})`,
+  },
+  {
     label: '$ruleTemplate',
     insertText: `
 var rule = {
@@ -630,6 +643,47 @@ const Keyword = [
     documentation:
       "headers:{ 'User-Agent': PC_UA, 'Referer': '', 'content-type': 'application/x-www-form-urlencoded', 'Cookie': ''}",
   },
+  {
+    label: 'tab_exclude',
+    insertText:
+      "tab_exclude:'排序',",
+    detail: '二级线路名称排除',
+    documentation:
+      "tab_exclude:'排序|榜单|猜你喜欢'",
+  },
+  {
+    label: 'cate_exclude',
+    insertText:
+      "cate_exclude:'今日更新|热榜',",
+    detail: '一级分类名称排除',
+    documentation:
+      "cate_exclude:'今日更新|热榜'",
+  },
+  {
+    label: 'tab_rename',
+    insertText:
+      "tab_rename: {'道长在线': '在线播放'},",
+    detail: '一级分类名称排除',
+    documentation:
+      "tab_rename: {'道长在线': '在线播放'}",
+  },
+  {
+    label: 'tab_order',
+    insertText:
+      "tab_order:['超清', '蓝光', '极速蓝光'],",
+    detail: '二级线路排序',
+    documentation:
+      "tab_order:['超清', '蓝光', '极速蓝光']'",
+  },
+  {
+    label: 'tab_remove',
+    insertText:
+      "tab_remove:['wjm3u8','ikm3u8','sdm3u8','M3U8','jinyingm3u8','fsm3u8','ukm3u8'],",
+    detail: '移除二级对应线路名相关的数据',
+    documentation:
+      "tab_remove:['wjm3u8','ikm3u8','sdm3u8','M3U8','jinyingm3u8','fsm3u8','ukm3u8']'",
+  },
+
 ];
 
 /**

--- a/src/renderer/src/utils/drpy/template.ts
+++ b/src/renderer/src/utils/drpy/template.ts
@@ -16,6 +16,34 @@ if (typeof Object.assign != 'function') {
 const getMubans = () => {
   const mubanDict = {
     // 模板字典
+    mx: {
+      title: '',
+      host: '',
+      url: '/vodshow/fyclass--------fypage---/',
+      searchUrl: '/vodsearch/**----------fypage---/',
+      class_parse: '.top_nav li;a&&Text;a&&href;.*/(.*?)/',
+      searchable: 2,
+      quickSearch: 0,
+      filterable: 0,
+      headers: {
+        'User-Agent': 'MOBILE_UA',
+      },
+      play_parse: true,
+      lazy: '',
+      limit: 6,
+      推荐: '.cbox_list;*;*;*;*;*',
+      double: true,
+      一级: 'ul.vodlist li;a&&title;a&&data-original;.pic_text&&Text;a&&href',
+      二级: {
+        title: 'h2&&Text;.detail_list&&ul:eq(1)&&li&&a:eq(2)&&Text',
+        img: '.vodlist_thumb&&data-original',
+        desc: '.content_detail&&li:eq(1)&&Text;.detail_list&&ul:eq(1)&&li&&a&&Text;.detail_list&&ul:eq(1)&&li&&a:eq(1)&&Text;.detail_list&&ul:eq(1)&&li:eq(2)&&Text;.detail_list&&ul:eq(1)&&li:eq(3)&&Text',
+        content: '.content_desc&&span&&Text',
+        tabs: '.play_source_tab&&a',
+        lists: '.content_playlist:eq(#id) li',
+      },
+      搜索: '*',
+    },
     mxpro: {
       title: '',
       host: '',
@@ -279,7 +307,7 @@ const getMubans = () => {
       searchUrl: '/index.php/ajax/suggest?mid=1&wd=**&limit=50',
       searchable: 2,
       quickSearch: 0,
-      headers: { 'User-Agent': 'MOBILE_UA' },
+      headers: {'User-Agent': 'MOBILE_UA'},
       url: '/index.php/api/vod#type=fyclass&page=fypage',
       filterable: 0, // 是否启用分类筛选,
       filter_url: '',
@@ -310,7 +338,7 @@ const getMubans = () => {
       detailUrl: '/api.php/provide/vod/?ac=detail&ids=fyid',
       searchUrl: '/api.php/provide/vod/?wd=**&pg=fypage',
       url: '/api.php/provide/vod/?ac=detail&pg=fypage&t=fyclass',
-      headers: { 'User-Agent': 'MOBILE_UA' },
+      headers: {'User-Agent': 'MOBILE_UA'},
       timeout: 5000,
       // class_name: '电影&电视剧&综艺&动漫',
       // class_url: '1&2&3&4',
@@ -347,4 +375,4 @@ const getMubans = () => {
   return JSON.parse(JSON.stringify(mubanDict));
 };
 
-export { getMubans };
+export {getMubans};


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [zyplayer 贡献指南]，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 组件样式/交互改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供