### PR TITLE
更换mobile_ua，修复搜索自动过验证由于没有自动继承全局headers导致的可能过不去验证的问题

### DIFF
--- a/src/renderer/src/config/ua.ts
+++ b/src/renderer/src/config/ua.ts
@@ -22,7 +22,7 @@ export default {
     },
     {
       name: 'MOBILE',
-      ua: 'Mozilla/5.0 (Linux; Android 11; M2007J3SC Build/RKQ1.200826.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.120 MQQBrowser/6.2 TBS/045714 Mobile Safari/537.36',
+      ua: 'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36',
     },
     {
       name: 'PC',

--- a/src/renderer/src/utils/drpy/drpy3.ts
+++ b/src/renderer/src/utils/drpy/drpy3.ts
@@ -1709,7 +1709,7 @@ const request = (url: string, obj: any = undefined, ocr_flag: boolean = false) =
     if (!keys.includes('user-agent')) {
       headers['User-Agent'] = MOBILE_UA;
       // fetch_params 里存在ua则优先，否则才默认手机UA
-      if( typeof(fetch_params) === 'object' && fetch_params.headers){
+      if( typeof(fetch_params) === 'object' && fetch_params && fetch_params.headers){
         let fetch_headers = keysToLowerCase(fetch_params.headers);
         if(fetch_headers['user-agent']){
           headers['User-Agent'] = fetch_headers['user-agent'];

--- a/src/renderer/src/utils/drpy/drpy3.ts
+++ b/src/renderer/src/utils/drpy/drpy3.ts
@@ -263,7 +263,7 @@ const pre = () => {
 let rule = {};
 // @ts-ignore
 let vercode = typeof pdfl === 'function' ? 'drpy3.1' : 'drpy3';
-const VERSION = `${vercode} 3.9.50beta19 202400526`;
+const VERSION = `${vercode} 3.9.50beta20 202400528`;
 /** 已知问题记录
  * 1.影魔的jinjia2引擎不支持 {{fl}}对象直接渲染 (有能力解决的话尽量解决下，支持对象直接渲染字符串转义,如果加了|safe就不转义)[影魔牛逼，最新的文件发现这问题已经解决了]
  * Array.prototype.append = Array.prototype.push; 这种js执行后有毛病,for in 循环列表会把属性给打印出来 (这个大毛病需要重点排除一下)
@@ -279,7 +279,7 @@ const VERSION = `${vercode} 3.9.50beta19 202400526`;
 
 /** 以下是内置变量和解析方法 **/
 var MOBILE_UA =
-  'Mozilla/5.0 (Linux; Android 11; M2007J3SC Build/RKQ1.200826.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.120 MQQBrowser/6.2 TBS/045714 Mobile Safari/537.36';
+  'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36';
 const PC_UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36';
 const UA = 'Mozilla/5.0';
@@ -1569,7 +1569,7 @@ const verifyCode = (url) => {
       // let submit_url = `${host}/index.php/ajax/verify_check`;
       // let submit_body = `type=search&verify=${code}`;
 
-      let html: any = request(submit_url, { headers: { Cookie: cookie, 'User-Agent': MOBILE_UA }, method: 'POST'});
+      let html: any = request(submit_url, { headers: { Cookie: cookie}, method: 'POST'});
       // let html: any = request(submit_url, { headers: { Cookie: cookie, 'User-Agent': MOBILE_UA }, method: 'POST',body:submit_body });
       html = JSON.parse(html);
 
@@ -1708,6 +1708,13 @@ const request = (url: string, obj: any = undefined, ocr_flag: boolean = false) =
     const keys = Object.keys(headers).map((it) => it.toLowerCase());
     if (!keys.includes('user-agent')) {
       headers['User-Agent'] = MOBILE_UA;
+      // fetch_params 里存在ua则优先，否则才默认手机UA
+      if( typeof(fetch_params) === 'object' && fetch_params.headers){
+        let fetch_headers = keysToLowerCase(fetch_params.headers);
+        if(fetch_headers['user-agent']){
+          headers['User-Agent'] = fetch_headers['user-agent'];
+        }
+      }
     }
     if (!keys.includes('referer')) {
       headers['Referer'] = getHome(url);

--- a/src/renderer/src/utils/drpy/drpy_suggestions/drpy_suggestions.ts
+++ b/src/renderer/src/utils/drpy/drpy_suggestions/drpy_suggestions.ts
@@ -655,7 +655,7 @@ const Keyword = [
     insertText: 'MOBILE_UA',
     detail: '应用注入的手机UA',
     documentation:
-      'Mozilla/5.0 (Linux; Android 11; M2007J3SC Build/RKQ1.200826.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.120 MQQBrowser/6.2 TBS/045714 Mobile Safari/537.36',
+      'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36',
   },
   {
     label: 'PC_UA',


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [zyplayer 贡献指南]，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

