### PR TITLE
添加 $schema json 协议文件

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,21 @@
+# zy-schema
+
+`easy.json` 是简易配置文件的 `$schema` 文件, 示例:
+
+```jsonc
+{
+  "$schema": "https://raw.githubusercontent.com/Hiram-Wong/ZyPlayer/main/schema/easy.json",
+  "sites": {
+    "default": "fff",
+    "data": [
+      {
+        "id": "fff",
+        "name": "菲菲影视",
+        "api": "https://www.example.com/api.php/provide/vod/",
+        "search": 0,
+        "type": 1
+      }
+    ]
+  }
+}
+```

--- a/schema/easy.json
+++ b/schema/easy.json
@@ -1,0 +1,224 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "zyplayer简易配置",
+  "type": "object",
+  "properties": {
+    "analyze": {
+      "type": "object",
+      "required": ["default", "data"],
+      "properties": {
+        "default": {
+          "title": "默认标识",
+          "type": "string",
+          "description": "默认标识 对应需设置为默认的id"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "title": "标识",
+                "type": "string",
+                "description": "id唯一值不可重复,不能数字,建议 uuid"
+              },
+              "name": {
+                "title": "名称",
+                "type": "string"
+              },
+              "url": {
+                "title": "解析源地址",
+                "type": "string",
+                "format": "uri"
+              },
+              "isActive": {
+                "title": "是否启用",
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": ["id", "name", "url"]
+          }
+        }
+      }
+    },
+    "iptv": {
+      "type": "object",
+      "required": ["default", "data"],
+      "properties": {
+        "default": {
+          "title": "默认标识",
+          "type": "string",
+          "description": "默认标识 对应需设置为默认的id"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "title": "标识",
+                "type": "string",
+                "description": "id唯一值不可重复,不能数字,建议 uuid"
+              },
+              "name": {
+                "title": "名称",
+                "type": "string"
+              },
+              "url": {
+                "title": "直播源地址",
+                "type": "string",
+                "format": "uri"
+              },
+              "type": {
+                "title": "类型",
+                "enum": ["remote", "local", "auto"],
+                "default": "remote",
+                "description": "remote为远程m3u local本地m3u文件路径"
+              },
+              "isActive": {
+                "title": "是否启用",
+                "type": "boolean",
+                "default": true
+              },
+              "epg": {
+                "title": "电子节目单地址",
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": ["id", "name", "url", "type"]
+          }
+        }
+      }
+    },
+    "sites": {
+      "type": "object",
+      "required": ["default", "data"],
+      "properties": {
+        "default": {
+          "title": "默认标识",
+          "type": "string",
+          "description": "默认标识 对应需设置为默认的id"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "title": "标识",
+                "type": "string",
+                "description": "id唯一值不可重复,不能数字,建议 uuid"
+              },
+              "name": {
+                "title": "名称",
+                "type": "string"
+              },
+              "api": {
+                "title": "站点源地址",
+                "type": "string",
+                "format": "uri"
+              },
+              "playUrl": {
+                "type": "string",
+                "format": "uri",
+                "description": "配合解析去url地址"
+              },
+              "search": {
+                "title": "搜索类型",
+                "type": "number",
+                "enum": [0, 1, 2],
+                "default": 1,
+                "description": "0:关闭\n1:聚合搜索\n2:本站搜索"
+              },
+              "group": {
+                "title": "分组",
+                "type": "string"
+              },
+              "isActive": {
+                "title": "是否启用",
+                "type": "boolean",
+                "default": true
+              },
+              "type": {
+                "title": "接口类型",
+                "type": "number",
+                "enum": [0,1,2,3,4],
+                "default": 1,
+                "description": "0:cms(xml)\n1:cms(json)\n2:drpy\n3:app(v3)\n4:app(v1)"
+              },
+              "ext": {
+                "title": "扩展参数",
+                "type": "string"
+              },
+              "categories": {
+                "title": "分类",
+                "type": "string",
+                "description": "按顺序展示所配置的分类 不配置则默认展示所有分类\n以 `,` 分割"
+              }
+            },
+            "required": ["id", "name", "api", "search", "type"]
+          }
+        }
+      }
+    },
+    "drive": {
+      "type": "object",
+      "required": ["default", "data"],
+      "properties": {
+        "default": {
+          "title": "默认标识",
+          "type": "string",
+          "description": "默认标识 对应需设置为默认的id"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "title": "标识",
+                "type": "string",
+                "description": "id唯一值不可重复,不能数字,建议 uuid"
+              },
+              "name": {
+                "title": "名称",
+                "type": "string"
+              },
+              "server": {
+                "title": "网盘地址",
+                "type": "string",
+                "format": "uri"
+              },
+              "startPage": {
+                "title": "开始页路径",
+                "type": "string",
+                "maxLength": 1024,
+                "format": "uri-template"
+              },
+              "search": {
+                "title": "是否支持搜索",
+                "type": "boolean"
+              },
+              "headers": {
+                "title": "请求头",
+                "type": "object"
+              },
+              "params": {
+                "title": "参数",
+                "type": "object"
+              },
+              "isActive": {
+                "title": "是否启用",
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": ["id", "name", "server"]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 文档改进

### 💡 需求背景和解决方案

这个 PR 希望能够添加配置的协议文件(参考: https://json-schema.apifox.cn)

- [x] ~~能够 codegen 生成协议文件吗?~~ 我想我们应该手写(ba
- [x] 有那些字段需要添加? (从 /README.md#数据结构 这里开始?)
	- [x] 添加"有意义"的 `一键配置格式` 的字段类型

在那之后, https://github.com/waifu-project/movie/issues/45 里的数据也能导出到 zy-player 中(即, 我了解了 zy 中的导入类型~)

> 生成的数据: https://cdn.jsdelivr.net/gh/waifu-project/v1@latest/zy.json

<img width="754" alt="image" src="https://github.com/Hiram-Wong/ZyPlayer/assets/45585937/40372746-c163-4959-9ec0-26a4b359fd2a">


### 📝 更新日志

- N-A